### PR TITLE
Update apns.js

### DIFF
--- a/lib/providers/apns.js
+++ b/lib/providers/apns.js
@@ -53,6 +53,9 @@ exports = module.exports = ApnsProvider;
 
 ApnsProvider.prototype._setupPushConnection = function(options) {
   var self = this;
+  if(options && !options.port){
+    delete options.port;  
+  }
   var connection = new apn.Connection(options);
 
   function errorHandler(err) {


### PR DESCRIPTION
do not work your example!

when port set as null, apn do not use default value.
so I delete port property
