### PR TITLE
Fixing duplicated notification data

### DIFF
--- a/lib/providers/apns.js
+++ b/lib/providers/apns.js
@@ -89,6 +89,7 @@ ApnsProvider.prototype._setupFeedback = function(options) {
 };
 
 ApnsProvider.prototype.pushNotification = function(notification, deviceToken) {
+  var keyIndexes = ['expiry', 'badge', 'sound', 'alert', '__cachedRelations', '__data', '__dataSource', '__strict'];
   // Note parameters are described here:
   //   http://bit.ly/apns-notification-payload
   var note = new apn.Notification();
@@ -99,7 +100,9 @@ ApnsProvider.prototype.pushNotification = function(notification, deviceToken) {
   note.payload = {};
 
   Object.keys(notification).forEach(function (key) {
-    note.payload[key] = notification[key];
+    if (keyIndexes.indexOf(key) < 0) {
+      note.payload[key] = notification[key];
+    }
   });
 
   debug('Pushing notification to %j:', deviceToken, note);


### PR DESCRIPTION
Fixing duplicated nofitication data and increasing payload size, which is limited in APNS to 256 bytes
