### PR TITLE
Ensure deviceType/token are populated from installation

### DIFF
--- a/lib/push-manager.js
+++ b/lib/push-manager.js
@@ -265,17 +265,24 @@ PushManager.prototype.notify = function(installation, notification, cb) {
     return cb(new Error('notification must be an object'));
   }
 
+  var appId = installation.appId;
+  var deviceToken = installation.deviceToken;
+  var deviceType = installation.deviceType;
+
   // Normalize the notification from a plain object
   // for remote calls
   if(!(notification instanceof this.Notification)) {
     notification = new this.Notification(notification);
-    if (!notification.isValid()) {
-      return cb(new loopback.ValidationError(notification));
-    }
   }
-  var appId = installation.appId;
-  var deviceToken = installation.deviceToken;
-  var deviceType = installation.deviceType;
+
+  // Populate the deviceType/deviceToken to avoid validation errors
+  // as both properties are required
+  notification.deviceType = deviceType || notification.deviceType;
+  notification.deviceToken = deviceToken || notification.deviceToken;
+
+  if (!notification.isValid()) {
+    return cb(new loopback.ValidationError(notification));
+  }
 
   this.configureApplication(
     appId,


### PR DESCRIPTION
/to @bajtos 
/cc @dashby3000 

The PR fixes an issue where the notifyById/notifyByQuery reports ValidationError if the Notification object doesn't have deviceType and deviceToken even these two properties should be populated from the matched installation instances.
