### PR TITLE
feature to change status instead of deleting records when devicesGone event received

### DIFF
--- a/lib/push-manager.js
+++ b/lib/push-manager.js
@@ -120,10 +120,19 @@ PushManager.prototype.configureProvider = function (deviceType, pushSettings) {
 
   var provider = new Provider(pushSettings);
   provider.on('devicesGone', function(deviceTokens) {
-    this.Installation.destroyAll({
-      deviceType: deviceType,
-      deviceToken: { inq: deviceTokens }
-    });
+    debug('markDevicesGone', this.Installation.definition.settings.markDevicesGone);
+    if (this.Installation.definition.settings.markDevicesGone) {
+      this.Installation.updateAll({
+        deviceType: deviceType,
+        deviceToken: { inq: deviceTokens }
+      },
+      { status: 'Deleted'});
+    } else {
+      this.Installation.destroyAll({
+        deviceType: deviceType,
+        deviceToken: { inq: deviceTokens }
+      });
+    }
   }.bind(this));
 
   provider.on('error', function(err) {


### PR DESCRIPTION
This is a first take at implementing the devicesGone option for
strongloop/loopback-component-push#57

A client would configure the `Installation` model with the `markDevicesGone` option in their model.json file to true.
```json
{
"markDevicesGone": true
}
```
If a provider sends the `devicesGone` event when the  the `markDevicesGone` setting is enabled all matching device tokens will have their status changed to `Deleted` instead actually being deleted from the database.

Questions:
* Configuration options?  I used the Installation model top level settings, not sure that is the best place.
* `markDevicesGone` doesn't seem like the best name, suggestions are welcome.
* `Deleted` status looked like it fit with the existing convention but that was convention I saw within the client applications; :tada: