### PR TITLE
update module to loopback 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage
 .loopbackrc
 xunit.xml
 checkstyle.xml
+doc

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  grunt.initConfig({
+    jsdoc : {
+      dist : {
+        src: ['lib/*.js', 'models/installation.js', 'models/notification.js'],
+        options: {
+          destination: 'doc'
+        }
+      }
+    },
+    watch: {
+      files: ['lib/*.js', 'models/*.js'],
+      tasks: ['jsdoc'],
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-jsdoc');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  // Default task(s).
+  grunt.registerTask('default', ['jsdoc']);
+};

--- a/index.js
+++ b/index.js
@@ -7,10 +7,8 @@ exports = module.exports = PushConnector;
 /**
  * Export two model classes as properties
  */
-exports.Installation = require('./models/installation');
-exports.Notification = require('./models/notification');
-
-var loopback = require('loopback');
+exports.Installation = require('./models').Installation;
+exports.Notification = require('./models').Notification;
 
 exports.createPushModel = function (options) {
   options = options || {};

--- a/lib/push-manager.js
+++ b/lib/push-manager.js
@@ -8,8 +8,8 @@ var loopback = require('loopback');
 var NodeCache = require('node-cache');
 var debug = require('debug')('loopback:component:push:push-manager');
 
-var Installation = require('../models/installation');
-var Notification = require('../models/notification');
+var Installation = require('../models').Installation;
+var Notification = require('../models').Notification;
 
 /*!
  * Exports a function to bootstrap PushManager
@@ -58,8 +58,8 @@ PushManager.prototype._defineDependencies = function () {
       Installation: {
         get: function () {
           if (!this._Installation) {
-            this._Installation = loopback.getModel(this.settings.installation)
-              || loopback.getModelByType(Installation);
+            this._Installation = loopback.findModel(this.settings.installation) ||
+              loopback.getModelByType(Installation);
           }
           return this._Installation;
         },
@@ -70,8 +70,8 @@ PushManager.prototype._defineDependencies = function () {
       Notification: {
         get: function () {
           if (!this._Notification) {
-            this._Notification = loopback.getModel(this.settings.notification)
-              || loopback.getModelByType(Notification);
+            this._Notification = loopback.findModel(this.settings.notification) ||
+              loopback.getModelByType(Notification);
           }
           return this._Notification;
         },
@@ -82,8 +82,8 @@ PushManager.prototype._defineDependencies = function () {
       Application: {
         get: function () {
           if (!this._Application) {
-            this._Application = loopback.getModel(this.settings.application)
-              || loopback.getModelByType(loopback.Application);
+            this._Application = loopback.findModel(this.settings.application) ||
+              loopback.getModelByType(loopback.Application);
           }
           return this._Application;
         },

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,21 @@
+// mostly borrowed from
+// https://github.com/strongloop/loopback-component-passport/blob/master/lib/index.js
+var loopback = require('loopback');
+var DataModel = loopback.PersistedModel || loopback.DataModel;
+
+function loadModel(jsonFile) {
+  var modelDefinition = require(jsonFile);
+  return DataModel.extend(modelDefinition.name, modelDefinition.properties);
+}
+
+var InstallationModel = loadModel('./installation.json');
+var NotificationModel = loadModel('./notification.json');
+
+/**
+ * Export two model classes as properties
+ */
+exports.Installation = require('./installation')(InstallationModel);
+exports.Notification = require('./notification')(NotificationModel);
+
+exports.Installation.autoAttach = 'db';
+exports.Notification.autoAttach = 'db';

--- a/models/installation.json
+++ b/models/installation.json
@@ -1,0 +1,33 @@
+{
+  "name": "Installation",
+  "plural": "Installations",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "properties": {
+    "appId": {
+      "required": true,
+      "type": "string"
+    },
+    "appVersion": "string",
+    "badge": "number",
+    "created": {
+      "defaultFn": "now",
+      "type": "date"
+    },
+    "deviceToken": {
+      "required": true,
+      "type": "string"
+    },
+    "deviceType": {
+      "required": true,
+      "type": "string"
+    },
+    "modified": "date",
+    "status": "string",
+    "subscriptions": [
+      "string"
+    ],
+    "timeZone": "string",
+    "userId": "string"
+  }
+}

--- a/models/notification.json
+++ b/models/notification.json
@@ -1,0 +1,31 @@
+{
+  "name": "Notification",
+  "plural": "Notifications",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "properties": {
+    "alert": "any",
+    "badge": "number",
+    "category": "string",
+    "collapseKey": "string",
+    "created": {
+      "defaultFn": "now",
+      "type": "date"
+    },
+    "delayWhileIdle": "boolean",
+    "deviceToken": {
+      "required": true,
+      "type": "string"
+    },
+    "deviceType": {
+      "required": true,
+      "type": "string"
+    },
+    "expirationInterval": "number",
+    "expirationTime": "date",
+    "modified": "date",
+    "scheduledTime": "date",
+    "sound": "string",
+    "status": "string"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,25 +11,29 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --timeout 30000 test/*test.js"
+    "test": "mocha"
   },
   "dependencies": {
-    "async": "~0.9.0",
-    "debug": "~1.0.2",
     "apn": "~1.6.0",
-    "node-gcm": "~0.9.11",
+    "async": "~0.9.0",
+    "debug": "~2.1.3",
+    "lodash": "^3.6.0",
     "mpns": "~2.1.0",
-    "node-cache": "~1.0.2"
+    "node-cache": "~1.0.2",
+    "node-gcm": "~0.9.11"
   },
   "devDependencies": {
-    "loopback": "1.x >=1.7.0",
-    "loopback-connector-mongodb": "1.x",
-    "loopback-testing": "~0.2.0",
-    "should": "*",
-    "mocha": "*",
-    "sinon": "*",
     "chai": "*",
-    "deep-extend": "*"
+    "deep-extend": "*",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-jsdoc": "^0.6.3",
+    "loopback": "2.x",
+    "loopback-connector-mongodb": "1.x",
+    "loopback-datasource-juggler": "2.x",
+    "loopback-testing": "1.1.x",
+    "mocha": "*",
+    "should": "*",
+    "sinon": "*"
   },
   "repository": {
     "type": "git",

--- a/test/apns.provider.test.js
+++ b/test/apns.provider.test.js
@@ -2,11 +2,8 @@
 var fs = require('fs');
 var path = require('path');
 var ApnsProvider = require('../lib/providers/apns');
-var Notification = require('../models/notification');
 var mockery = require('./helpers/mockery').apns;
 var objectMother = require('./helpers/object-mother');
-var expect = require('chai').expect;
-var sinon = require('sinon');
 
 var aDeviceToken = 'a-device-token';
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,26 @@
+/* exported global */
+global.chai = require('chai');
+global.should = require('chai').should();
+global.expect = require('chai').expect;
+global.AssertionError = require('chai').AssertionError;
+global.lt = require('loopback-testing');
+global.loopback = require('loopback');
+global.assert = require('assert');
+
+global.sinon = require('sinon');
+
+global.ds = global.loopback.createDataSource('db', {
+  connector: global.loopback.Memory
+});
+
+global.Application = global.loopback.Application;
+global.Application.attachTo(global.ds);
+
+global.PushConnector = require('../');
+global.Installation = PushConnector.Installation;
+global.Installation.attachTo(global.ds);
+
+global.Notification = PushConnector.Notification;
+global.Notification.attachTo(global.ds);
+
+// global.chai.use(require('sinon-chai'));

--- a/test/device-registration.test.js
+++ b/test/device-registration.test.js
@@ -1,17 +1,3 @@
-var loopback = require(('loopback'));
-var assert = require('assert');
-
-var ds = loopback.createDataSource('db', {connector: loopback.Memory});
-
-var Application = loopback.Application;
-Application.attachTo(ds);
-
-var Installation = require('../models/installation');
-Installation.attachTo(ds);
-
-var Notification = require('../models/notification');
-Notification.attachTo(ds);
-
 describe('Installation', function () {
     var registration = null;
 
@@ -60,4 +46,3 @@ describe('Installation', function () {
     });
 
 });
-

--- a/test/gcm.provider.test.js
+++ b/test/gcm.provider.test.js
@@ -1,11 +1,8 @@
 
 var extend = require('util')._extend;
 var GcmProvider = require('../lib/providers/gcm');
-var Notification = require('../models/notification');
 var mockery = require('./helpers/mockery').gcm;
 var objectMother = require('./helpers/object-mother');
-var expect = require('chai').expect;
-var sinon = require('sinon');
 
 var aDeviceToken = 'a-device-token';
 var aDeviceTokenList = [

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--timeout 30000
+--reporter spec
+--require test/common

--- a/test/push-manager.test.js
+++ b/test/push-manager.test.js
@@ -2,14 +2,8 @@
 var async = require('async');
 
 var PushManager = require('../lib/push-manager');
-var Notification = require('../models/notification');
-var loopback = require('loopback');
-var Application = loopback.Application;
-var Installation = require('../models/installation');
 var NodeCache = require('node-cache');
 
-var expect = require('chai').expect;
-var sinon = require('sinon');
 var mockery = require('./helpers/mockery').stub;
 var TestDataBuilder = require('loopback-testing').TestDataBuilder;
 var ref = TestDataBuilder.ref;

--- a/test/push-notification.test.js
+++ b/test/push-notification.test.js
@@ -1,14 +1,4 @@
-var loopback = require('loopback');
-var assert = require('assert');
-var path = require('path');
-
-var ds = loopback.createDataSource('db', {connector: loopback.Memory});
-
-var PushConnector = require('../index');
 var PushModel = PushConnector.createPushModel({dataSource: ds});
-var Application = loopback.Application;
-var Installation = PushConnector.Installation;
-var Notification = PushConnector.Notification;
 
 var objectMother = require('./helpers/object-mother');
 
@@ -83,4 +73,3 @@ describe('PushNotification', function () {
     });
 
 });
-


### PR DESCRIPTION
The existing code had models that used beforeCreate calls which can be replaced by the operation hooks.  My current code is using loopback 2.0 so importing this was causing errors.

Here’s the breakdown:

* Created a Grunfile to help with the local doc generation
* Added an index.js file to the models directory to load up the models from both JSON and JS files.  Mostly borrowed from [loopback-component-passport/li
b/index.js](https://github.com/strongloop/loopback-component-passport/blob/master/li
b/index.js)
* In the push-manager I moved from `getModel` to `findModel` because  
[7316048afc1164ed91a004a8f4f58f3603df456f](https://github.com/strongloop/loopback/commit/7316048afc1164ed91a004a8f4f58f3603df456f) changed `getModel` to throw an
error.
* The Installation model was stripped down to do most of the work in the JSON file and remove the `beforeCreate` call in favour of a ‘before save’ observer.  The `created` attribute is now generated from the `defaultFn`.  And the `modified` attribute can safely be updated in the ‘before save’ function.
* The Notification model was stripped down so the definition was in the JSON file.  A lot of the comments within are duplicated though I did like the inline comments more than the top level jsdoc ones. Similarly the `beforeCreate` function was replaced with a ‘before save’ function.
* package.json: npm sorted the dependencies which makes the diff annoying.
 * I updated the debug module, couldn’t see why we needed to stay on the 1.x version
 * added lodash as I used it in a couple places and intend to use it a bit more as I clean up more of the code in general
 * updated loopback to 2.x
 * updated loopback-datasource-juggler to 2.x as well
 * updated loopback-testing to 1.1.x
 * simplified the test script with the help of moca.opts
* .gitignore, added a line for the doc directory to ignore the jsdoc output for local testing

Tests
* I added a `common.js` file which I haven’t seen this team use yet but have seen as common practice in other places so I don’t have repeat myself with lots of includes on every test.  I’m inclined to move most
of the testings across modules to this kind of format if this approach is acceptable.
* Added a `mocha.opts` file which takes the options away from the `package.json`
* Thanks to the `common.js` I removed a lot of duplicate includes from the test files.