### PR TITLE
fix not installed

### DIFF
--- a/example/server-2.0/server/datasources.json
+++ b/example/server-2.0/server/datasources.json
@@ -5,7 +5,7 @@
   },
   "push": {
     "name": "push",
-    "connector": "loopback-component-push",
+    "connector": "loopback-component-push/lib/push-connector",
     "installation": "installation",
     "notification": "notification",
     "application": "application"


### PR DESCRIPTION
without the changes we always got the below error:

```
Error: 
WARNING: LoopBack connector "loopback-component-push" is not installed as any of the following modules:

 ./connectors/loopback-component-push
loopback-connector-loopback-component-push
loopback-component-push
```

That actually is because the `loopback-component-push/index.js` is invalid connector compatible source file, this confuse me so long time.