### PR TITLE
adding jscs and jshint to the pretest, jsdocs updates

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,13 @@
+{
+  "excludeFiles": ["example", "node_modules", "doc"],
+  "maximumLineLength": {
+     "value": 120,
+     "allowComments": true,
+     "allowRegex": true
+  },
+  "validateJSDoc": {
+    "checkParamNames": true,
+    "checkRedundantParams": true,
+    "requireParamTypes": true
+  }
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
-node_modules
-example/html
+/example/
+/node_modules/
+/doc/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+"node": true,
+"eqnull" : true,
+"indent": 2,
+"undef": true,
+"newcap": true,
+"nonew": true,
+"sub": true,
+"laxcomma": true,
+"laxbreak": true
+}

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -1,3 +1,5 @@
+// this file has no tests so avoid refactor and ignore jshint for now
+/*jshint ignore: start */
 var serial,__hasProp = {}.hasOwnProperty;
 
 serial = 0;

--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -60,7 +60,7 @@ GcmProvider.prototype.pushNotification = function(notification, deviceToken) {
 
 GcmProvider.prototype._createMessage = function(notification) {
   // Message parameters are documented here:
-  //   http://developer.android.com/google/gcm/server.html#params
+  //   https://developers.google.com/cloud-messaging/server-ref
   var message = new gcm.Message({
     timeToLive: notification.getTimeToLiveInSecondsFromNow(),
     collapseKey: notification.collapseKey,
@@ -68,7 +68,7 @@ GcmProvider.prototype._createMessage = function(notification) {
   });
 
   Object.keys(notification).forEach(function (key) {
-    if (notification[key] != null) {
+    if (notification[key] !== null && typeof notification[key] !== 'undefined') {
       message.addData(key, notification[key]);
     }
   });

--- a/lib/push-connector.js
+++ b/lib/push-connector.js
@@ -2,8 +2,8 @@ var loopback = require('loopback');
 var PushManager = require('./push-manager');
 /**
  * Export the initialize method to Loopback DataSource
- * @param dataSource
- * @param callback
+ * @param {Object} dataSource Loopback dataSource (Memory, etc).
+ * @param {Function} callback (unused)
  */
 exports.initialize = function (dataSource, callback) {
     var settings = dataSource.settings || {};

--- a/lib/push-manager.js
+++ b/lib/push-manager.js
@@ -20,10 +20,11 @@ module.exports = PushManager;
 
 /**
  * The PushManager class.
- *
+ * See the {@link https://github.com/tcs-de/nodecache#options|node-cache options}
+ * for more information on the settings parameters.
  * @options {Object} settings The push settings.
  * @property {Number} ttlInSeconds Time-to-live, in seconds.
- * @property {Number} checkPeriodInSeconds
+ * @property {Number} checkPeriodInSeconds A number in seconds for the automatic delete check interval
  *
  * @class
  * @header PushManager(settings)
@@ -108,9 +109,10 @@ PushManager.providers = {
 /**
  * Configure push notification for a given device type. Return null when
  * no provider is registered for the device type.
- * @param {String} deviceType The device type
+ * @param {String} deviceType The type of device (android, ios)
  * @param {Object} pushSettings The push settings
- * @returns {*}
+ * @returns {Provider|null} A provider from PushManager.providers (GcmProvider, ApnsProvider)
+ * matching the deviceType (android, ios)
  */
 PushManager.prototype.configureProvider = function (deviceType, pushSettings) {
   var Provider = PushManager.providers[deviceType];
@@ -136,7 +138,8 @@ PushManager.prototype.configureProvider = function (deviceType, pushSettings) {
 /**
  * Lookup or set up push notification service for the given appId
  * @param {String} appId The application id
- * @returns {*}
+ * @param {String} deviceType The type of device (android, ios)
+ * @param {function(Error=,Application)} cb Callback function called with `cb(err, obj)` signature.
  */
 PushManager.prototype.configureApplication = function (appId, deviceType, cb) {
   assert.ok(cb, 'callback should be defined');
@@ -307,22 +310,22 @@ PushManager.prototype.notify = function(installation, notification, cb) {
  /**
  * Push notification to installations for given devices tokens, device type and app.
  *
- * @param {appId} application id
- * @param {deviceType} type of device (android, ios )
- * @param {deviceTokens} device tokens of recipients.
- * @param {Notification} notification The notification to send.
+ * @param {String} appId application id
+ * @param {String} deviceType type of device (android, ios)
+ * @param {String[]} deviceTokens device tokens of recipients.
+ * @param {Notification} notification The Notification object to send.
  * @param {function(Error=)} cb
  */
 PushManager.prototype.notifyMany = function(appId, deviceType, deviceTokens, notification, cb) {
     assert(appId, 'appId should be defined');
-    assert(deviceType, 'deviceType should be defined')
+    assert(deviceType, 'deviceType should be defined');
     assert(cb, 'callback should be defined');
 
     if(!(typeof notification === 'object' && notification)) {
         return cb(new Error('notification must be an object'));
     }
 
-    if(!(typeof deviceTokens === 'object' && deviceTokens && deviceTokens.length > 0)) {
+    if(!(Array.isArray(deviceTokens) && deviceTokens.length > 0)) {
         return cb(new Error('deviceTokens must be an array'));
     }
 

--- a/models/installation.js
+++ b/models/installation.js
@@ -32,12 +32,10 @@ module.exports = function(Installation) {
 
   /**
    * Find installations by application id/version
-   * @param {String} deviceType The device type
+   * @param {String} deviceType The type of device (android, ios)
    * @param {String} appId The application id
    * @param {String} [appVersion] The application version
-   * @callback {Function} cb The callback function
-   * @param {Error|String} err The error object
-   * @param {Installation[]} installations The selected installations
+   * @param {function(Error=,Installation[])} cb Callback function passed to find() with `cb(err, obj[])` signature.
    */
   Installation.findByApp = function(deviceType, appId, appVersion, cb) {
     if (!cb && typeof appVersion === 'function') {
@@ -54,13 +52,9 @@ module.exports = function(Installation) {
 
   /**
    * Find installations by user id
+   * @param {String} deviceType The type of device (android, ios)
    * @param {String} userId The user id
-   * @param {String} deviceType The device type
-   * @param {Function} cb The callback function
-   *
-   * @callback {Function} cb The callback function
-   * @param {Error|String} err The error object
-   * @param {Installation[]} installations The selected installations
+   * @param {function(Error=,Installation[])} cb Callback function passed to find() with `cb(err, obj[])` signature.
    */
   Installation.findByUser = function(deviceType, userId, cb) {
     var filter = {where: {userId: userId, deviceType: deviceType}};
@@ -69,12 +63,9 @@ module.exports = function(Installation) {
 
   /**
    * Find installations by subscriptions
-   * @param {String|String[]} subscriptions A list of subscriptions
-   * @param {String} deviceType The device type
-   *
-   * @callback {Function} cb The callback function
-   * @param {Error|String} err The error object
-   * @param {Installation[]} installations The selected installations
+   * @param {String} deviceType The type of device (android, ios)
+   * @param {String|String[]} subscriptions Either a comma/space delimited string or array of subscriptions
+   * @param {function(Error=,Installation[])} cb Callback function passed to find() with `cb(err, obj[])` signature.
    */
   Installation.findBySubscriptions = function(deviceType, subscriptions, cb) {
     if (typeof subscriptions === 'string') {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.9.3",
     "mpns": "^2.1.0",
-    "node-cache": "^2.2.0",
+    "node-cache": "^2.1.1",
     "node-gcm": "^0.9.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "main": "index.js",
   "scripts": {
+    "pretest": "jscs . && jshint .",
     "test": "mocha"
   },
   "dependencies": {
@@ -27,6 +28,8 @@
     "deep-extend": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jsdoc": "^0.6.6",
+    "jscs": "^1.13.1",
+    "jshint": "^2.8.0",
     "loopback": "^2.18.0",
     "loopback-connector-mongodb": "^1.8.0",
     "loopback-datasource-juggler": "^2.29.0",

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,14 @@
+{
+"mocha": true,
+"globals": {
+  "expect": true,
+  "assert": true,
+  "Application": true,
+  "Notification": true,
+  "PushConnector": true,
+  "Installation": true,
+  "loopback": true,
+  "sinon": true,
+  "ds": true
+ }
+}

--- a/test/common.js
+++ b/test/common.js
@@ -22,5 +22,3 @@ global.Installation.attachTo(global.ds);
 
 global.Notification = PushConnector.Notification;
 global.Notification.attachTo(global.ds);
-
-// global.chai.use(require('sinon-chai'));

--- a/test/device-registration.test.js
+++ b/test/device-registration.test.js
@@ -2,12 +2,12 @@ describe('Installation', function () {
     var registration = null;
 
     it('registers a new installation', function (done) {
-
+        var token = '75624450 3c9f95b4 9d7ff821 20dc193c a1e3a7cb 56f60c2e f2a19241 e8f33305';
         Installation.create({
             appId: 'MyLoopbackApp',
             appVersion: '1',
             userId: 'raymond',
-            deviceToken: '75624450 3c9f95b4 9d7ff821 20dc193c a1e3a7cb 56f60c2e f2a19241 e8f33305',
+            deviceToken: token,
             deviceType: 'ios',
             created: new Date(),
             modified: new Date(),
@@ -22,7 +22,7 @@ describe('Installation', function () {
                 assert.equal(reg.appId, 'MyLoopbackApp');
                 assert.equal(reg.userId, 'raymond');
                 assert.equal(reg.deviceType, 'ios');
-                assert.equal(reg.deviceToken, '75624450 3c9f95b4 9d7ff821 20dc193c a1e3a7cb 56f60c2e f2a19241 e8f33305');
+                assert.equal(reg.deviceToken, token);
 
                 assert(reg.created);
                 assert(reg.modified);
@@ -36,7 +36,7 @@ describe('Installation', function () {
                     assert.equal(reg.appId, 'MyLoopbackApp');
                     assert.equal(reg.userId, 'raymond');
                     assert.equal(reg.deviceType, 'ios');
-                    assert.equal(reg.deviceToken, '75624450 3c9f95b4 9d7ff821 20dc193c a1e3a7cb 56f60c2e f2a19241 e8f33305');
+                    assert.equal(reg.deviceToken, token);
                     done(err, results);
 
                 });

--- a/test/gcm.provider.test.js
+++ b/test/gcm.provider.test.js
@@ -70,7 +70,7 @@ describe('GCM provider', function() {
     });
 
     it('emits "devicesGone" when GCM returns NotRegistered', function(done) {
-      var errorResult = aGcmResult([{ 'error': 'NotRegistered' }])
+      var errorResult = aGcmResult([{ 'error': 'NotRegistered' }]);
 
       mockery.pushNotificationCallbackArgs = [null, errorResult];
 
@@ -171,6 +171,19 @@ describe('GCM provider', function() {
 
     var message = mockery.firstPushNotificationArgs()[0];
     expect(message.data).to.eql({ });
+  });
+
+  it('ignores Notification properties null or undefined', function() {
+    var notification = aNotification({
+      aFalse: false,
+      aTrue: true,
+      aNull: null,
+      anUndefined: undefined
+    });
+    provider.pushNotification(notification, aDeviceToken);
+
+    var message = mockery.firstPushNotificationArgs()[0];
+    expect(message.data).to.eql({ aFalse: false, aTrue: true });
   });
 
   function givenProviderWithConfig(pushSettings) {

--- a/test/helpers/mockery/gcm.mockery.js
+++ b/test/helpers/mockery/gcm.mockery.js
@@ -38,7 +38,7 @@ mockery.pushNotificationCallbackArgs = [];
 
 /**
  * Setup GCM send to always return the given error.
- * @param err
+ * @param {Error} err
  */
 mockery.givenPushNotificationFailsWith = function(err) {
   mockery.pushNotificationCallbackArgs = [err];

--- a/test/helpers/mockery/stub.mockery.js
+++ b/test/helpers/mockery/stub.mockery.js
@@ -49,7 +49,7 @@ mockery.pushNotificationCallbackArgs = [];
  * Function for emitting "devicesGone" event.
  * It reports a warning when the Provider was not
  * by the subject under test.
- * @param devices {Array.<Object>|Object}
+ * @param {Array.<Object>|Object} devices
  */
 mockery.emitDevicesGone = function(devices) {
   console.error('Warning: cannot emit devicesGone, as the provider' +


### PR DESCRIPTION
Creating minimal jshint and jscs configs that required mostly doc updates and little code reformatting.
Ignoring the payload module as there aren’t tests for the file.
In the gcm provider started using the ‘truthy’ test instead of the `!= null` test and added a few extra test parameters to ensure it works as advertised.