### PR TITLE
downgrade to node-cache@2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.9.3",
     "mpns": "^2.1.0",
-    "node-cache": "^2.2.0",
+    "node-cache": "^2.1.1",
     "node-gcm": "^0.9.15"
   },
   "devDependencies": {


### PR DESCRIPTION
See the [release history](https://www.npmjs.com/package/node-cache#release-history) for [node-cache](tcs-de/nodecache).  The 2.2.0 version of node-cache was revoked for a breaking change and bumped to 3.0.0, leaving the 2.1.1 version as the latest 2.x release.