### PR TITLE
Adding priority capability for Android provider

### DIFF
--- a/example/server-2.0/server/push-demo.js
+++ b/example/server-2.0/server/push-demo.js
@@ -12,7 +12,8 @@ module.exports = function (app) {
         badge: badge++,
         sound: 'ping.aiff',
         alert: '\uD83D\uDCE7 \u2709 ' + 'Hello',
-        messageFrom: 'Ray'
+        messageFrom: 'Ray',
+        priority: 'high' //normal by default
       });
 
       PushModel.notifyById(req.params.id, note, function (err) {

--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -64,7 +64,8 @@ GcmProvider.prototype._createMessage = function(notification) {
   var message = new gcm.Message({
     timeToLive: notification.getTimeToLiveInSecondsFromNow(),
     collapseKey: notification.collapseKey,
-    delayWhileIdle: notification.delayWhileIdle
+    delayWhileIdle: notification.delayWhileIdle,
+    priority: notification.priority || 'normal'
   });
 
   Object.keys(notification).forEach(function (key) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^3.9.3",
     "mpns": "^2.1.0",
     "node-cache": "^2.1.1",
-    "node-gcm": "^0.9.15"
+    "node-gcm": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",


### PR DESCRIPTION
This pull request allows loopback-component-push to handle the priority of notifications for the gcm provider. 
I also debugged the ios provider and have seen that the low level component(apn) is using priority=10 by default. For us this setting is ok but it would be great to have a compatibility layer like:
normal(android) -> 5(ios)
high(android) -> 10(ios)