### PR TITLE
omit examples from published tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ xunit.xml
 checkstyle.xml
 example/server-2.0/client/public/vendor
 doc
+example


### PR DESCRIPTION
This reduces the .tgz downloaded from npm from 1.5M to 108K.

It also removes some Android JAR files from the tgz, which are
problematic from a distribution point of view.