### PR TITLE
Add priority option for gcm provider

### DIFF
--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -64,7 +64,8 @@ GcmProvider.prototype._createMessage = function(notification) {
   var message = new gcm.Message({
     timeToLive: notification.getTimeToLiveInSecondsFromNow(),
     collapseKey: notification.collapseKey,
-    delayWhileIdle: notification.delayWhileIdle
+    delayWhileIdle: notification.delayWhileIdle,
+    priority: notification.priority || 'normal'
   });
 
   Object.keys(notification).forEach(function (key) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^3.9.3",
     "mpns": "^2.1.0",
     "node-cache": "^2.1.1",
-    "node-gcm": "^0.9.15"
+    "node-gcm": "^0.14.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",


### PR DESCRIPTION
GCM Service has a option which is "provider".

GCM attempts to deliver high priority messages immediately.

We should able to control this option.
