### PR TITLE
allow contentAvailable for notifications

### DIFF
--- a/lib/providers/apns.js
+++ b/lib/providers/apns.js
@@ -100,6 +100,11 @@ ApnsProvider.prototype.pushNotification = function(notification, deviceToken) {
   note.contentAvailable = notification.contentAvailable;
   note.urlArgs = notification.urlArgs;
   note.payload = {};
+  
+  if(notification.contentAvailable) {
+    note.setContentAvailable(notification.contentAvailable);
+    delete notification.contentAvailable;
+  }
 
   Object.keys(notification).forEach(function (key) {
     note.payload[key] = notification[key];


### PR DESCRIPTION
This allows to send push notification marked with "content-available" in iOS. 
Allows apps to (maybe silently) refresh data (e.g. from the web) on incoming notifications.

fixes: #96