### PR TITLE
Revert dev-dependency on loopback to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "deep-extend": "^0.4.0",
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
-    "loopback": "^3.0.0",
+    "loopback": "^2.36.0",
     "loopback-connector-mongodb": "^1.8.0",
+    "loopback-datasource-juggler": "^2.53.0",
     "mocha": "^2.2.0",
     "should": "^6.0.0",
     "sinon": "^1.14.0"


### PR DESCRIPTION
LoopBack 3.x is dropping support for Node v0.10/v0.12, which we still support in 1.x branch of this component. If we stayed with LoopBack 3.x, then we would get CI failures on those two old platforms.

Connect to strongloop/loopback#2807

