### PR TITLE
Adding support to FCM and change packagename for npm (ignore package.json)

### DIFF
--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -81,7 +81,7 @@ GcmProvider.prototype._createMessage = function(notification) {
 
   var propNames = Object.keys(notification);
   // GCM does not have reserved message parameters for alert or badge, adding them as data.
-  propNames.push('alert', 'badge');
+  propNames.push('alert', 'badge','message');
 
   propNames.forEach(function(key) {
     if (notification[key] !== null &&
@@ -89,6 +89,8 @@ GcmProvider.prototype._createMessage = function(notification) {
       message.addData(key, notification[key]);
     }
   });
+
+  message.addNotification(notification.message);
 
   return message;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "loopback-component-push",
-  "version": "3.0.0-alpha.1",
+  "name": "loopback-component-push-fcm",
+  "version": "3.0.0-alpha.2",
   "description": "Loopback Push Notification",
   "keywords": [
     "StrongLoop Labs",
@@ -41,7 +41,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strongloop/loopback-component-push.git"
+    "url": "https://github.com/oscar-anton/loopback-component-push"
   },
   "license": "Artistic-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^3.10.1",
     "mpns": "^2.1.0",
     "node-cache": "^3.2.1",
-    "node-gcm": "^0.14.0",
+    "node-gcm": "^0.14.4",
     "strong-globalize": "^2.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The android client can't receive a notification via FCM because the addNotification method was missing.