### PR TITLE
GCM: Iterate __data object to send complete msg payload

### DIFF
--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -79,13 +79,16 @@ GcmProvider.prototype._createMessage = function(notification) {
     delayWhileIdle: notification.delayWhileIdle,
   });
 
-  var propNames = Object.keys(notification);
-  // GCM does not have reserved message parameters for alert or badge, adding them as data.
-  propNames.push('alert', 'badge');
+  // Dont send these keys in the message payload
+  var exclusions = ['id', 'deviceToken', 'deviceType']
 
-  propNames.forEach(function(key) {
+  // We need to use data in order to get additional payload
+  Object.keys(notification.__data)
+  .filter(function(key) { return exclusions.indexOf(key) == -1})
+  .forEach(function(key) {
     if (notification[key] !== null &&
         typeof notification[key] !== 'undefined') {
+          debug('__Data: ' + key);
       message.addData(key, notification[key]);
     }
   });


### PR DESCRIPTION
### Description
GCM messages sent by the connector are missing data. This is because the code to construct the message iterates over the Notification's keys. However, the notification is not a simple Javascript object, but a loopback model instance. Most of the notification data is stored in `notification.__data`.

This PR changes how data is added to the message. We add data by iterating over `Object.keys(notification.__data)` instead of `Object.keys(notification)`. In addition, we add a list of data that is used internally by the component that does not need to be sent (id, etc). We filter the keys so the excluded items are not sent.

#### Related issues

#106 - This PR actually fixes this, as it adds *all* data to the message payload. This bug was incorrectly marked as a duplicate of #82. Rather, #82 is a subset of #106, as 82 is referring to two specific keys.

#114 makes sure alert and badge are sent by explicitly adding those keys to the data to be sent. This PR goes about things the other way, sending all data unless it is excluded.

#103 is most likely related to this PR.

