### PR TITLE
Add FCM support with addNotification in node-gcm 1.4.4

### DIFF
--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -90,5 +90,8 @@ GcmProvider.prototype._createMessage = function(notification) {
     }
   });
 
+  message.addNotification('title', notification.messageFrom);
+  message.addNotification('body', notification.alert);
+
   return message;
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^3.10.1",
     "mpns": "^2.1.0",
     "node-cache": "^3.2.1",
-    "node-gcm": "^0.14.0",
+    "node-gcm": "^0.14.4",
     "strong-globalize": "^2.6.2"
   },
   "devDependencies": {

--- a/test/gcm.provider.test.js
+++ b/test/gcm.provider.test.js
@@ -174,6 +174,21 @@ describe('GCM provider', function() {
     expect(message.params.delayWhileIdle, 'delayWhileIdle').to.equal(true);
   });
 
+  it('adds appropriate fcm properties to the notification', function() {
+    var note = {
+      messageFrom: 'StrongLoop',
+      alert: 'Hello from StrongLoop',
+    };
+    var notification = aNotification(note);
+    provider.pushNotification(notification, aDeviceToken);
+
+    var message = mockery.firstPushNotificationArgs()[0];
+    expect(message.params.notification).to.eql({
+      title: note.messageFrom,
+      body: note.alert,
+    });
+  });
+
   it('ignores Notification properties not applicable', function() {
     var notification = aNotification(objectMother.allNotificationProperties());
     provider.pushNotification(notification, aDeviceToken);


### PR DESCRIPTION
### Description
Notifications aren't sent to the new FCM system with the latest version of `node-gcm`. This uses the [`addNotification()`](https://github.com/ToothlessGear/node-gcm#notification-usage) method to add the expected notification properties to the message to be sent.

The properties used are `messageFrom` for the title and `alert` for the body as this makes it fully compatible with the [existing docs](http://loopback.io/doc/en/lb2/Push-notifications.html#overview) on notifications (ie. the result on the device will be the same on both iOS and Android)

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
