### PR TITLE
Add support for mutable-content key in apns provider

### DIFF
--- a/lib/providers/apns.js
+++ b/lib/providers/apns.js
@@ -199,6 +199,7 @@ function _createNotification(notification, pushOptions) {
   note.alert = notification.alert;
   note.category = notification.category;
   note.contentAvailable = notification.contentAvailable;
+  note.mutableContent = notification.mutableContent;
   note.urlArgs = notification.urlArgs;
   note.payload = {};
 

--- a/models/notification.json
+++ b/models/notification.json
@@ -9,6 +9,7 @@
     "category": "string",
     "collapseKey": "string",
     "contentAvailable": "boolean",
+    "mutableContent": "boolean",
     "created": {
       "defaultFn": "now",
       "type": "date"


### PR DESCRIPTION
Add support for mutable-content key in push notification to iOS application.

### Description
mutable-content key makes possible to use [UNNotificationServiceExtension object](https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension) in iOS applications.

#### Related issues
#152 
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
