### PR TITLE
Add support for data-only notifications

### DIFF
--- a/lib/providers/gcm.js
+++ b/lib/providers/gcm.js
@@ -90,14 +90,24 @@ GcmProvider.prototype._createMessage = function(notification) {
     }
   });
 
-  message.addNotification('title', notification.messageFrom);
-  message.addNotification('body', notification.alert);
+  addKey(message, 'title', notification, 'messageFrom');
+  addKey(message, 'body', notification, 'alert');
+
   ['icon', 'sound', 'badge', 'tag', 'color', 'click_action']
     .forEach(function(prop) {
       if (notification[prop]) {
-        message.addNotification(prop, notification[prop]);
+        addKey(message, prop, notification);
       }
     });
 
   return message;
 };
+
+function addKey(message, key, notification, prop) {
+  prop = prop || key;
+  if (notification.dataOnly) {
+    message.addData(key, notification[prop]);
+  } else {
+    message.addNotification(key, notification[prop]);
+  }
+}

--- a/test/gcm.provider.test.js
+++ b/test/gcm.provider.test.js
@@ -223,6 +223,31 @@ describe('GCM provider', function() {
     expect(message.params.data).to.deep.equal({aFalse: false, aTrue: true});
   });
 
+  it('supports data-only notifications', function() {
+    var note = {
+      messageFrom: 'StrongLoop',
+      alert: 'Hello from StrongLoop',
+      icon: 'logo.png',
+      sound: 'ping.tiff',
+      badge: 5,
+      dataOnly: true,
+    };
+    var notification = aNotification(note);
+    provider.pushNotification(notification, aDeviceToken);
+
+    var message = mockery.firstPushNotificationArgs()[0];
+    expect(message.params.data).to.eql({
+      messageFrom: 'StrongLoop',
+      alert: 'Hello from StrongLoop',
+      title: 'StrongLoop',
+      body: 'Hello from StrongLoop',
+      icon: 'logo.png',
+      sound: 'ping.tiff',
+      badge: 5,
+      dataOnly: true,
+    });
+  });
+
   function givenProviderWithConfig(pushSettings) {
     pushSettings = extend({}, pushSettings);
     pushSettings.gcm = extend({}, pushSettings.gcm);


### PR DESCRIPTION
### Description

Adds a 'dataOnly' key which allows creating android notifications using only data properties instead of notification properties.

The specific use-case here is allowing "data-only" notification payloads as "notification" do not forward the data:

https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#notification-vs-data-payloads

#### Related issues

- closes #165

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

Note, I avoided the ES6 syntax as the lint file still specifies ES5 only