### PR TITLE
Fix missing title on iOS notifications

### DIFF
--- a/lib/providers/apns.js
+++ b/lib/providers/apns.js
@@ -200,8 +200,8 @@ function _createNotification(notification, pushOptions) {
   note.category = notification.category;
   note.contentAvailable = notification.contentAvailable;
   note.urlArgs = notification.urlArgs;
+  note.title = notification.title || notification.messageFrom;
   note.payload = {};
-
   // the topic is necessary to identify
   // the app which receives this notification
   note.topic = pushOptions.bundle;

--- a/test/apns.provider.test.js
+++ b/test/apns.provider.test.js
@@ -59,6 +59,8 @@ describe('APNS provider', function() {
       givenProviderWithConfig();
 
       var notification = aNotification({
+        alert: 'You have a message from StrongLoop',
+        messageFrom: 'StrongLoop',
         contentAvailable: true,
         category: 'my-category',
         urlArgs: ['foo', 'bar'],
@@ -75,6 +77,9 @@ describe('APNS provider', function() {
       expect(payload.aps.category, 'aps.category').to.equal('my-category');
       expect(payload.aps['url-args'], 'aps.url-args').to.have.length(2);
       expect(payload.arbitrary, 'arbitrary').to.equal('baz');
+      expect(payload.aps.alert.title, 'title').to.equal('StrongLoop');
+      expect(payload.aps.alert.body, 'body').to
+        .equal('You have a message from StrongLoop');
 
       done();
     });


### PR DESCRIPTION
### Description

Expects a 'title' property
https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW5

The loopback push documentation hints to a `messageFrom` property which would show the 'From' on a push notification.

http://loopback.io/doc/en/lb3/Push-notifications.html#send-push-notifications

This change allows the 'messageFrom' to populate the 'title' field allowing notifications that render as:

```
<Message From>
<Message>
```

Which is currently supported by the GCM provider:

https://github.com/strongloop/loopback-component-push/blob/master/lib/providers/gcm.js#L93

Also adds missing check for the 'body' property which should have been tested previously.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
